### PR TITLE
Add styles for headings, bold, italic in markup

### DIFF
--- a/themes/sunrise.json
+++ b/themes/sunrise.json
@@ -367,6 +367,33 @@
 				"foreground": "#c99e00",
 				"fontStyle": ""
 			}
+		},
+		{
+			"name": "Markup Heading",
+			"scope": [
+				"markup.heading"
+			],
+			"settings": {
+				"foreground": "#4a8f8f"
+			}
+		},
+		{
+			"name": "Markup Bold",
+			"scope": [
+				"markup.bold"
+			],
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup Italic",
+			"scope": [
+				"markup.italic"
+			],
+			"settings": {
+				"fontStyle": "italic"
+			}
 		}
 	]
 }


### PR DESCRIPTION
This updates styles for markup (markdown, etc), so that:

- Headings are teal
- Bold text is bold
- Italic text is italic

Very minor changes, but does a lot for the markdown experience :)

Thanks for the great theme, btw, I use it all the time!